### PR TITLE
ci: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -36,6 +36,8 @@ jobs:
     needs: package
     name: Upload latest release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -47,10 +49,9 @@ jobs:
       #   run: ls -R
 
       - name: Upload binaries to release
-        uses: crowbarmaster/GH-Automatic-Releases@latest
+        uses: softprops/action-gh-release@v2
         with:
-          title: "Latest Themes Package"
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
+          tag_name: latest
+          name: "Latest Themes Package"
           prerelease: false
           files: release/edgetx-themes.zip

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # - name: Validate themes
       #   run: some validation
@@ -24,7 +24,7 @@ jobs:
         run: mkdir release && zip -r release/edgetx-themes.zip THEMES
 
       - name: Upload zip package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: themes-latest
           path: release
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: themes-latest
           path: release


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` v4 → v6, `actions/upload-artifact` v4 → v7, and `actions/download-artifact` v4 → v8
- Replaces the unmaintained `crowbarmaster/GH-Automatic-Releases` with `softprops/action-gh-release@v2`, which is the community-standard replacement
- Adds `permissions: contents: write` to the `upload` job, required by the softprops action

## Reviewer notes

The softprops action uses the same `GITHUB_TOKEN` secret but no longer needs it passed explicitly via `repo_token`. Parameter mapping: `title` → `name`, `automatic_release_tag` → `tag_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)