### PR TITLE
ci: add release cleanup and bump softprops to v3

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -39,17 +39,29 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
           name: themes-latest
           path: release
 
-      # - name: Display structure of downloaded files
-      #   run: ls -R
+      - name: Update latest tag
+        run: |
+          git tag -f latest
+          git push -f origin latest
+
+      - name: Delete previous latest release
+        run: gh release delete latest --yes || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: latest
           name: "Latest Themes Package"


### PR DESCRIPTION
## Summary

- Add `actions/checkout@v6` (with `fetch-depth: 0`) to the `upload` job — required for git tag operations
- Force-update the `latest` tag and delete the previous latest release before re-uploading, preventing stale assets from accumulating
- Bump `softprops/action-gh-release` from `v2` to `v3`

## Test plan

- [ ] Merge and verify the `upload` job runs end-to-end on a push to `main`
- [ ] Confirm old `latest` release is deleted and replaced cleanly
- [ ] Confirm `release/edgetx-themes.zip` is attached to the new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)