### PR TITLE
feat: add git-cliff changelog generation to release workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -45,9 +45,47 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
-  upload:
+  generate-changelog:
     if: github.event_name != 'pull_request'
     needs: package
+    runs-on: ubuntu-latest
+    outputs:
+      changelog: ${{ steps.changelog.outputs.changelog }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install git-cliff
+        run: |
+          VERSION=$(wget -qO- https://api.github.com/repos/orhun/git-cliff/releases/latest \
+            | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//')
+          FILENAME="git-cliff-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          wget -O git-cliff.tar.gz \
+            "https://github.com/orhun/git-cliff/releases/download/v${VERSION}/${FILENAME}"
+          tar -xzvf git-cliff.tar.gz
+          sudo mv "git-cliff-${VERSION}/git-cliff" /usr/local/bin/
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV_SHA=$(git rev-parse latest 2>/dev/null || echo "")
+          if [ -n "$PREV_SHA" ]; then
+            RANGE="${PREV_SHA}..HEAD"
+          else
+            RANGE=""
+          fi
+          git-cliff $RANGE --strip all --output CHANGELOG.md
+          {
+            echo "changelog<<EOF"
+            cat CHANGELOG.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  upload:
+    if: github.event_name != 'pull_request'
+    needs: [package, generate-changelog]
     name: Upload latest release
     runs-on: ubuntu-latest
     permissions:
@@ -80,11 +118,12 @@ jobs:
           tag_name: latest
           name: "Latest Themes Package"
           prerelease: false
+          body: ${{ needs.generate-changelog.outputs.changelog }}
           files: release/all/edgetx-themes.zip
 
   upload-individual:
     if: github.event_name != 'pull_request'
-    needs: package
+    needs: [package, generate-changelog]
     name: Upload individual theme releases
     runs-on: ubuntu-latest
     permissions:
@@ -117,4 +156,5 @@ jobs:
           tag_name: individual-themes
           name: "Individual Theme Packages"
           prerelease: false
+          body: ${{ needs.generate-changelog.outputs.changelog }}
           files: release/individual/*.zip

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,25 @@
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") -%}
+### {{ group }}
+{% for commit in commits -%}
+- {{ commit.message | split(pat="\\n") | first | trim }}
+{% endfor %}
+{% endfor -%}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+sort_commits = "oldest"
+
+commit_parsers = [
+  { message = "^feat", group = "🚀 Features" },
+  { message = "^fix", group = "🐛 Bug Fixes" },
+  { message = "^docs?", group = "📝 Documentation" },
+  { message = "^ci", group = "🔧 CI/CD" },
+  { message = "^chore", group = "🧹 Chores" },
+  { body = ".*", group = "📦 Other" },
+]


### PR DESCRIPTION
## Summary

- Adds a new `generate-changelog` job to `build_release.yml` that installs [git-cliff](https://github.com/orhun/git-cliff) and generates a changelog from the previous `latest` tag to `HEAD`
- Both the `upload` (Latest Themes Package) and `upload-individual` (Individual Theme Packages) release jobs now receive the changelog as their release body, so GitHub releases show what changed since the last push
- Adds `cliff.toml` at the repo root configuring conventional-commit parsing with groups suited to this repo: Features, Bug Fixes, Documentation, CI/CD, Chores, and Other

## How it works

1. Before the `latest` tag is force-pushed, the job resolves the commit SHA it currently points to
2. git-cliff generates a changelog over the range `<prev-sha>..HEAD` (full history on first run when no `latest` tag exists yet)
3. The changelog is passed via job outputs to both upload jobs and injected as the `body` field on `softprops/action-gh-release`

## Reviewer notes

- The `generate-changelog` job is gated with `if: github.event_name != 'pull_request'` — it won't run on PRs
- git-cliff is fetched at runtime (latest release) using the same `wget` pattern as EdgeTX/edgetx's `release-drafter.yml`
- Conventional commits in this repo already include PR numbers (e.g. `feat: add theme (#93)`) so they appear naturally in the changelog body
- Commits that don't match any conventional-commit prefix fall into the **📦 Other** group rather than being dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)