### PR TITLE
ci: switch build_release trigger to paths allowlist and add workflow_dispatch

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -3,11 +3,14 @@ name: Build Release ZIP
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**.md"
+    paths:
+      - 'THEMES/**'
+      - '.github/workflows/build_release.yml'
   pull_request:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - 'THEMES/**'
+      - '.github/workflows/build_release.yml'
+  workflow_dispatch:
 
 jobs:
   package:


### PR DESCRIPTION
## Summary

- Replaces `paths-ignore: ["**.md"]` denylist with a `paths:` allowlist (`THEMES/**`, `.github/workflows/build_release.yml`) so the workflow only triggers on relevant changes
- Adds `workflow_dispatch` for manual triggering

## Test plan

- [ ] Push a commit touching only a non-theme file (e.g. a tool script) — workflow should **not** trigger
- [ ] Push a commit touching a file under `THEMES/` — workflow **should** trigger and complete package + release
- [ ] Push a commit editing `build_release.yml` itself — workflow **should** trigger
- [ ] Manually trigger via Actions UI using the new `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)