### PR TITLE
fix: ensure upload job is always marked as latest release

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -121,6 +121,7 @@ jobs:
           tag_name: latest
           name: "Latest Themes Package"
           prerelease: false
+          make_latest: true
           body: ${{ needs.generate-changelog.outputs.changelog }}
           files: release/all/edgetx-themes.zip
 
@@ -159,5 +160,6 @@ jobs:
           tag_name: individual-themes
           name: "Individual Theme Packages"
           prerelease: false
+          make_latest: false
           body: ${{ needs.generate-changelog.outputs.changelog }}
           files: release/individual/*.zip


### PR DESCRIPTION
## Summary
- Added `make_latest: true` to the `upload` job's release step so the combined-package release is always marked as the GitHub \"latest\" release
- Added `make_latest: false` to the `upload-individual` job's release step to prevent it from ever claiming \"latest\"

## Why
Both jobs run in parallel after `package` completes. Without explicit `make_latest` settings, whichever job finishes last would overwrite the other as the \"latest\" release — a non-deterministic race condition. This fix makes the outcome deterministic regardless of job completion order.

## Reviewer notes
No logic changes — only two lines added to the workflow YAML.